### PR TITLE
updated fse 2025 abstract deadline

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -112,8 +112,9 @@
   link: https://conf.researchr.org/track/fse-2025/fse-2025-research-papers
   deadline: 
   - "2024-09-12 23:59"
+  - "2024-09-05 23:59"
   abstract_deadline: 
-  - "2024-09-12 23:59"
+  - "2024-09-05 23:59"
   date: July 23 - 27, 2025
   place: Trondheim, Norway
   note: Mandatory abstract deadline on September 5 2024.


### PR DESCRIPTION
Paper registration: September 5, 2024 (to register a paper, paper title, abstract, author list, and some additional metadata are required; title and abstract must contain sufficient information for effective bidding; registrations containing empty or generic title and abstract may be dropped)
Full paper submission: September 12, 2024